### PR TITLE
fix: 修复url端口无效,更改swagger配置生成路径为相对路径

### DIFF
--- a/src/Swagger/Swagger.php
+++ b/src/Swagger/Swagger.php
@@ -634,12 +634,14 @@ class Swagger {
 
         //是否开启swagger文档功能
         if ($openSwagger) {
-            $http    = $this->confSwagger['schemes'][0] ?? 'http';
-            $domain  = OsHelper::getDomain($this->confSwagger['host']);
-            $siteUrl = UrlHelper::formatUrl(strtolower("{$http}://" . $domain));
+            $host    = $this->confSwagger['host'];
+            $domain  = OsHelper::getDomain($host);
+            $port    = substr($host,strripos($host,":") + 1);
+            $port    = strlen($port) > 0 ? $port : null;
+            $full    = $domain . ($port ?":".$port: '');
             $urls    = [];
 
-            $this->confSwagger['host'] = $domain;
+            $this->confSwagger['host'] = $full;
             $swaggerAll                = $this->confSwagger; //包含全部版本
 
             // 生成版本分组文件
@@ -649,7 +651,7 @@ class Swagger {
                 $swaggerAll['paths']  = array_merge_recursive(($swaggerAll['paths'] ?? []), $group['paths']);
 
                 $versionFile = "{$baseName}-{$group['name']}.json";
-                array_push($urls, ['url' => "{$siteUrl}/{$swaggerDir}/{$versionFile}", 'name' => "{$group['name']} -- {$group['description']}"]);
+                array_push($urls, ['url' => "/{$versionFile}", 'name' => "{$group['name']} -- {$group['description']}"]);
 
                 $filePath = $saveDir . $versionFile;
                 file_put_contents($filePath, json_encode($swaggerData, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
@@ -657,7 +659,7 @@ class Swagger {
 
             // 全部版本的接口
             $baseName .= ".json";
-            array_unshift($urls, ['url' => "{$siteUrl}/{$swaggerDir}/{$baseName}", 'name' => "all version apis"]);
+            array_unshift($urls, ['url' => "/{$baseName}", 'name' => "all version apis"]);
             $filePath = $saveDir . $baseName;
             file_put_contents($filePath, json_encode($swaggerAll, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
 


### PR DESCRIPTION
1. 修复 配置文件中端口号无效 , 支持配置成N级别目录 xxx.com:9501/c/a/b/c
2. 更改swagger 配置文件生成路径的方式为相对路径。